### PR TITLE
Switch checked example & addition of inner labels

### DIFF
--- a/yewprint-doc/src/switch/example.rs
+++ b/yewprint-doc/src/switch/example.rs
@@ -41,25 +41,28 @@ impl Component for Example {
                     disabled=self.props.disabled
                     inline=self.props.inline
                     large=self.props.large
-                    label=html!("Enabled")
+                    label=html!{<strong>{"Enabled"}</strong>}
                 />
                 <Switch
                     disabled=self.props.disabled
                     inline=self.props.inline
                     large=self.props.large
-                    label=html!(<em>{"Public"}</em>)
+                    label=html!{<em>{"Public"}</em>}
                 />
                 <Switch
                     disabled=self.props.disabled
                     inline=self.props.inline
                     large=self.props.large
-                    label=html!{<strong>{"Cooperative"}</strong>}
+                    checked=true
+                    label=html!{<u>{"Cooperative"}</u>}
                 />
                 <Switch
                     disabled=self.props.disabled
                     inline=self.props.inline
                     large=self.props.large
-                    label=html!(<u>{"Containing Text"}</u>)
+                    label=html!{"Containing Text"}
+                    innerLabelChecked={"on".to_string()}
+                    innerLabel={"off".to_string()}
                 />
             </div>
         }

--- a/yewprint-doc/src/switch/example.rs
+++ b/yewprint-doc/src/switch/example.rs
@@ -61,8 +61,8 @@ impl Component for Example {
                     inline=self.props.inline
                     large=self.props.large
                     label=html!{"Containing Text"}
-                    innerLabelChecked={"on".to_string()}
-                    innerLabel={"off".to_string()}
+                    inner_label_checked={"on".to_string()}
+                    inner_label={"off".to_string()}
                 />
             </div>
         }

--- a/yewprint/src/switch.rs
+++ b/yewprint/src/switch.rs
@@ -48,7 +48,7 @@ impl Component for Switch {
     }
 
     fn view(&self) -> Html {
-        let maybe_display_label = move || -> Html {
+        let display_label = {
             if self.props.inner_label.is_some() || self.props.inner_label_checked.is_some() {
                 let inner_label = self.props.inner_label.as_deref().unwrap_or_default();
                 let inner_label_checked = self.props.inner_label_checked.as_ref();
@@ -66,7 +66,9 @@ impl Component for Switch {
                             </div>
                         </div>
                         <div class=classes!("bp3-control-indicator-child")>
-                            <div class=classes!("bp3-switch-inner-text")>{inner_label.to_string()}</div>
+                            <div class=classes!("bp3-switch-inner-text")>
+                                {inner_label.to_string()}
+                            </div>
                         </div>
                     </>
                 }
@@ -96,7 +98,7 @@ impl Component for Switch {
             <span
                 class=classes!("bp3-control-indicator")
             >
-                {maybe_display_label()}
+                {display_label}
             </span>
             {self.props.label.clone()}
             </label>

--- a/yewprint/src/switch.rs
+++ b/yewprint/src/switch.rs
@@ -20,6 +20,10 @@ pub struct SwitchProps {
     pub label: yew::virtual_dom::VNode,
     #[prop_or_default]
     pub class: Classes,
+    #[prop_or_default]
+    pub innerLabelChecked: Option<String>,
+    #[prop_or_default]
+    pub innerLabel: Option<String>,
 }
 
 impl Component for Switch {
@@ -44,6 +48,32 @@ impl Component for Switch {
     }
 
     fn view(&self) -> Html {
+        let maybe_display_label = move || -> Html {
+            if self.props.innerLabel.is_some() || self.props.innerLabelChecked.is_some() {
+                html! {
+                    <>
+                        <div class=classes!("bp3-control-indicator-child")>
+                            <div class=classes!("bp3-switch-inner-text")>
+                                {
+                                    if let Some(label_checked) = self.props.innerLabelChecked.as_ref() {
+                                        label_checked.clone()
+                                    } else {
+                                        self.props.innerLabel.clone().unwrap_or_default()
+                                    }
+                                }
+                            </div>
+                        </div>
+                        <div class=classes!("bp3-control-indicator-child")>
+                            <div class=classes!("bp3-switch-inner-text")>{self.props.innerLabel.clone().unwrap_or_default()}</div>
+                        </div>
+                    </>
+                }
+            } else {
+                html! {}
+            }
+        };
+
+
         html! {
             <label
                 class=classes!(
@@ -64,6 +94,7 @@ impl Component for Switch {
             <span
                 class=classes!("bp3-control-indicator")
             >
+                {maybe_display_label()}
             </span>
             {self.props.label.clone()}
             </label>

--- a/yewprint/src/switch.rs
+++ b/yewprint/src/switch.rs
@@ -50,7 +50,7 @@ impl Component for Switch {
     fn view(&self) -> Html {
         let maybe_display_label = move || -> Html {
             if self.props.inner_label.is_some() || self.props.inner_label_checked.is_some() {
-                let inner_label = self.props.inner_label.as_ref().unwrap_or_default();
+                let inner_label = self.props.inner_label.as_deref().unwrap_or_default();
                 let inner_label_checked = self.props.inner_label_checked.as_ref();
                 html! {
                     <>

--- a/yewprint/src/switch.rs
+++ b/yewprint/src/switch.rs
@@ -60,13 +60,13 @@ impl Component for Switch {
                                     if let Some(label_checked) = inner_label_checked {
                                         label_checked.clone()
                                     } else {
-                                        inner_label.clone()
+                                        inner_label.to_string()
                                     }
                                 }
                             </div>
                         </div>
                         <div class=classes!("bp3-control-indicator-child")>
-                            <div class=classes!("bp3-switch-inner-text")>{inner_label.clone()}</div>
+                            <div class=classes!("bp3-switch-inner-text")>{inner_label.to_string()}</div>
                         </div>
                     </>
                 }

--- a/yewprint/src/switch.rs
+++ b/yewprint/src/switch.rs
@@ -50,21 +50,23 @@ impl Component for Switch {
     fn view(&self) -> Html {
         let maybe_display_label = move || -> Html {
             if self.props.inner_label.is_some() || self.props.inner_label_checked.is_some() {
+                let inner_label = self.props.inner_label.clone().unwrap_or_default();
+                let inner_label_checked = self.props.inner_label_checked.as_ref();
                 html! {
                     <>
                         <div class=classes!("bp3-control-indicator-child")>
                             <div class=classes!("bp3-switch-inner-text")>
                                 {
-                                    if let Some(label_checked) = self.props.inner_label_checked.as_ref() {
+                                    if let Some(label_checked) = inner_label_checked {
                                         label_checked.clone()
                                     } else {
-                                        self.props.inner_label.clone().unwrap_or_default()
+                                        inner_label
                                     }
                                 }
                             </div>
                         </div>
                         <div class=classes!("bp3-control-indicator-child")>
-                            <div class=classes!("bp3-switch-inner-text")>{self.props.inner_label.clone().unwrap_or_default()}</div>
+                            <div class=classes!("bp3-switch-inner-text")>{inner_label}</div>
                         </div>
                     </>
                 }

--- a/yewprint/src/switch.rs
+++ b/yewprint/src/switch.rs
@@ -21,9 +21,9 @@ pub struct SwitchProps {
     #[prop_or_default]
     pub class: Classes,
     #[prop_or_default]
-    pub innerLabelChecked: Option<String>,
+    pub inner_label_checked: Option<String>,
     #[prop_or_default]
-    pub innerLabel: Option<String>,
+    pub inner_label: Option<String>,
 }
 
 impl Component for Switch {
@@ -49,27 +49,27 @@ impl Component for Switch {
 
     fn view(&self) -> Html {
         let maybe_display_label = move || -> Html {
-            if self.props.innerLabel.is_some() || self.props.innerLabelChecked.is_some() {
+            if self.props.inner_label.is_some() || self.props.inner_label_checked.is_some() {
                 html! {
                     <>
                         <div class=classes!("bp3-control-indicator-child")>
                             <div class=classes!("bp3-switch-inner-text")>
                                 {
-                                    if let Some(label_checked) = self.props.innerLabelChecked.as_ref() {
+                                    if let Some(label_checked) = self.props.inner_label_checked.as_ref() {
                                         label_checked.clone()
                                     } else {
-                                        self.props.innerLabel.clone().unwrap_or_default()
+                                        self.props.inner_label.clone().unwrap_or_default()
                                     }
                                 }
                             </div>
                         </div>
                         <div class=classes!("bp3-control-indicator-child")>
-                            <div class=classes!("bp3-switch-inner-text")>{self.props.innerLabel.clone().unwrap_or_default()}</div>
+                            <div class=classes!("bp3-switch-inner-text")>{self.props.inner_label.clone().unwrap_or_default()}</div>
                         </div>
                     </>
                 }
             } else {
-                html! {}
+                Html::default()
             }
         };
 

--- a/yewprint/src/switch.rs
+++ b/yewprint/src/switch.rs
@@ -76,8 +76,6 @@ impl Component for Switch {
                 Html::default()
             }
         };
-
-
         html! {
             <label
                 class=classes!(

--- a/yewprint/src/switch.rs
+++ b/yewprint/src/switch.rs
@@ -50,7 +50,7 @@ impl Component for Switch {
     fn view(&self) -> Html {
         let maybe_display_label = move || -> Html {
             if self.props.inner_label.is_some() || self.props.inner_label_checked.is_some() {
-                let inner_label = self.props.inner_label.clone().unwrap_or_default();
+                let inner_label = self.props.inner_label.as_ref().unwrap_or_default();
                 let inner_label_checked = self.props.inner_label_checked.as_ref();
                 html! {
                     <>
@@ -60,13 +60,13 @@ impl Component for Switch {
                                     if let Some(label_checked) = inner_label_checked {
                                         label_checked.clone()
                                     } else {
-                                        inner_label
+                                        inner_label.clone()
                                     }
                                 }
                             </div>
                         </div>
                         <div class=classes!("bp3-control-indicator-child")>
-                            <div class=classes!("bp3-switch-inner-text")>{inner_label}</div>
+                            <div class=classes!("bp3-switch-inner-text")>{inner_label.clone()}</div>
                         </div>
                     </>
                 }


### PR DESCRIPTION
- Resolves #120 
- Adds inner labels
- fixes the example to look like https://blueprintjs.com/docs/#core/components/switch

Question: How do I fix the inner label properties case?
They should be in `cameCase` however I didn't find a way to rename them using `yew`. One way would be to suppress the `#[warn(non_snake_case)]`.