### PR TITLE
Change Github links to reference Yewprint org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <a href="https://yewprint.rm.rs"><img src="./yewprint-doc/src/logo.svg" height="32" /></a> <a href="https://yewprint.rm.rs">Yewprint</a> ![Rust](https://github.com/cecton/yewprint/workflows/Rust/badge.svg) [![Netlify Status](https://api.netlify.com/api/v1/badges/17f076ed-49e5-4185-921e-5c5759de2fdb/deploy-status)](https://app.netlify.com/sites/epic-poincare-f8adaa/deploys) [![Discord](https://img.shields.io/discord/701068342760570933)](https://discord.gg/NAFcwhp) [![API Docs](https://img.shields.io/badge/docs.rs-yewprint-green)](https://yewprint.rm.rs/api/yewprint/)
+# <a href="https://yewprint.rm.rs"><img src="./yewprint-doc/src/logo.svg" height="32" /></a> <a href="https://yewprint.rm.rs">Yewprint</a> ![Rust](https://github.com/yewprint/yewprint/workflows/Rust/badge.svg) [![Netlify Status](https://api.netlify.com/api/v1/badges/17f076ed-49e5-4185-921e-5c5759de2fdb/deploy-status)](https://app.netlify.com/sites/epic-poincare-f8adaa/deploys) [![Discord](https://img.shields.io/discord/701068342760570933)](https://discord.gg/NAFcwhp) [![API Docs](https://img.shields.io/badge/docs.rs-yewprint-green)](https://yewprint.rm.rs/api/yewprint/)
 
 
 It's [Blueprint](https://blueprintjs.com), but for
@@ -14,14 +14,14 @@ Installation
 ## Use as a library (in your project)
 
 ```toml
-yewprint = { git = "https://github.com/cecton/yewprint.git", branch = "main" }
+yewprint = { git = "https://github.com/yewprint/yewprint.git", branch = "main" }
 ```
 
 You will also need the CSS from Blueprint. There is a helper crate that can be
 used to automatize this:
 
 ```toml
-yewprint-css = { git = "https://github.com/cecton/yewprint.git", branch = "main" }
+yewprint-css = { git = "https://github.com/yewprint/yewprint.git", branch = "main" }
 ```
 
 Then you can add this to your build process:

--- a/yewprint-doc/src/app.rs
+++ b/yewprint-doc/src/app.rs
@@ -104,7 +104,7 @@ impl Component for App {
                                     </div>
                                     <a
                                         class=classes!("bp3-text-muted")
-                                        href="https://github.com/cecton/yewprint"
+                                        href="https://github.com/yewprint/yewprint"
                                         target="_blank"
                                     >
                                         <small>{"View on GitHub"}</small>


### PR DESCRIPTION
There are several links that reference @cecton's repo. Since this repo was moved to the Yewprint org, the link will redirect properly, but the link changes will make it easier for people to understand what the intention is.