### PR TITLE
Use the `pull_request_target` event instead of `pull_request`.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,7 @@
 name: PR Workflow
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [ main ]
 
 env:


### PR DESCRIPTION
This PR use new  `pull_request_target` event, which behaves in an almost identical way to the `pull_request` event with the same set of filters and payload. However, instead of running against the workflow and code from the merge commit, the event runs against the workflow and code from the base of the pull request. This means the workflow is running from a trusted source and is given access to a read/write token as well as secrets