### PR TITLE
Fix Light/Dark theme switch

### DIFF
--- a/yewprint-doc/src/app.rs
+++ b/yewprint-doc/src/app.rs
@@ -55,7 +55,7 @@ impl Component for App {
     fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::ToggleLight => {
-                DARK.with(|x| x.replace(!*x.borrow()));
+                DARK.with(|x| x.replace_with(|&mut x| !x));
             }
             Msg::GoToMenu(event, doc_menu) => {
                 event.prevent_default();


### PR DESCRIPTION
Clicking the Light/Dark theme button in the menu was failing with:

`panicked at 'already borrowed: BorrowMutError', yewprint-doc/src/app.rs:58:33`

`RefCell::replace` uses `borrow_mut` internally to replace the value which results in double borrowing attempt in this case.

Using `RefCell::replace_with` fixes the issue