### PR TITLE
Make Slider component work on touch devices

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ gloo = "0.8"
 id_tree = { version = "1.8", optional = true }
 implicit-clone = "0.3.5"
 wasm-bindgen = "0.2"
-web-sys = { version = "0.3", features = ["DomRect", "Element", "Event", "HtmlSelectElement", "DomTokenList"] }
+web-sys = { version = "0.3", features = ["DomRect", "Element", "Event", "HtmlSelectElement", "DomTokenList", "Element"] }
 yew = "0.20"
 yew-callbacks = "0.2.1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,8 @@
     clippy::inconsistent_struct_constructor,
     clippy::type_complexity,
     clippy::derive_partial_eq_without_eq,
-    clippy::uninlined_format_args
+    clippy::uninlined_format_args,
+    clippy::derivable_impls
 )]
 
 mod button_group;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@ use yew::Classes;
 // See https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
 #[allow(dead_code)]
 const MOUSE_EVENT_BUTTONS_NONE: u16 = 0;
+#[allow(dead_code)]
 const MOUSE_EVENT_BUTTONS_PRIMARY: u16 = 1;
 #[allow(dead_code)]
 const MOUSE_EVENT_BUTTONS_SECONDARY: u16 = 2;

--- a/src/slider.rs
+++ b/src/slider.rs
@@ -222,7 +222,7 @@ impl<T: ImplicitClone + PartialEq + 'static> Component for Slider<T> {
                     ctx.props().vertical.then_some("bp3-vertical"),
                 )}
                 ref={self.slider_ref.clone()}
-                style={"touch-action: pan-y; -webkit-touch-callout: none;"}
+                style={"touch-action: pan-y pinch-zoom; -webkit-touch-callout: none;"}
                 onpointerdown={(ctx.props().values.len() > 1).then(
                     || ctx.link().batch_callback(
                         |event: PointerEvent| {

--- a/src/slider.rs
+++ b/src/slider.rs
@@ -221,7 +221,17 @@ impl<T: ImplicitClone + PartialEq + 'static> Component for Slider<T> {
                     || ctx.link().batch_callback(
                         |event: PointerEvent| {
                             if event.is_primary() {
-                                vec![Msg::PointerDown, Msg::PointerMove { client_x: event.client_x() }]
+                                if event.pointer_type() == "touch" {
+                                    // for touch devices, wait for some dragging
+                                    // to occur to know if we're dragging the
+                                    // slider or scrolling the page. this avoids
+                                    // some jumps on pointercancel, in most
+                                    // cases. it also doesn't affect "clicks"
+                                    // which do one-time adjustments.
+                                    vec![Msg::PointerDown]
+                                } else {
+                                    vec![Msg::PointerDown, Msg::PointerMove { client_x: event.client_x() }]
+                                }
                             } else {
                                 vec![]
                             }

--- a/src/slider.rs
+++ b/src/slider.rs
@@ -189,8 +189,8 @@ impl<T: ImplicitClone + PartialEq + 'static> Component for Slider<T> {
                 onpointerdown={(ctx.props().values.len() > 1).then(
                     || ctx.link().batch_callback(
                         |event: PointerEvent| {
-                            let start = Msg::StartChange { pointer_id: event.pointer_id() };
-                            if event.pointer_type() == "mouse" {
+                            if event.is_primary() && event.pointer_type() == "mouse" {
+                                let start = Msg::StartChange { pointer_id: event.pointer_id() };
                                 vec![start, Msg::Mouse(event)]
                             } else {
                                 vec![]
@@ -290,8 +290,8 @@ impl<T: ImplicitClone + PartialEq + 'static> Component for Slider<T> {
                                     onpointerdown={(ctx.props().values.len() > 1).then(
                                         || ctx.link().batch_callback(
                                             |event: PointerEvent| {
-                                                let start = Msg::StartChange { pointer_id: event.pointer_id() };
-                                                if event.pointer_type() == "touch" {
+                                                if event.is_primary() && event.pointer_type() == "touch" {
+                                                    let start = Msg::StartChange { pointer_id: event.pointer_id() };
                                                     vec![start, Msg::Mouse(event)]
                                                 } else {
                                                     vec![]

--- a/src/slider.rs
+++ b/src/slider.rs
@@ -227,6 +227,9 @@ impl<T: ImplicitClone + PartialEq + 'static> Component for Slider<T> {
                     || ctx.link().batch_callback(
                         |event: PointerEvent| {
                             if event.is_primary() {
+                                let down = Msg::PointerDown {
+                                    pointer_id: Some(event.pointer_id())
+                                };
                                 if event.pointer_type() == "touch" {
                                     // for touch devices, wait for some dragging
                                     // to occur to know if we're dragging the
@@ -234,9 +237,9 @@ impl<T: ImplicitClone + PartialEq + 'static> Component for Slider<T> {
                                     // some jumps on pointercancel, in most
                                     // cases. it also doesn't affect "clicks"
                                     // which do one-time adjustments.
-                                    vec![Msg::PointerDown { pointer_id: Some(event.pointer_id()) }]
+                                    vec![down]
                                 } else {
-                                    vec![Msg::PointerDown { pointer_id: Some(event.pointer_id()) }, Msg::PointerMove { client_x: event.client_x() }]
+                                    vec![down, Msg::PointerMove { client_x: event.client_x() }]
                                 }
                             } else {
                                 vec![]
@@ -250,7 +253,9 @@ impl<T: ImplicitClone + PartialEq + 'static> Component for Slider<T> {
                             if let Some(target) = event.target() {
                                 if let Some(el) = target.dyn_ref::<web_sys::Element>() {
                                     if el.has_pointer_capture(event.pointer_id()) {
-                                        return vec![Msg::PointerMove { client_x: event.client_x() }];
+                                        return vec![
+                                            Msg::PointerMove { client_x: event.client_x() }
+                                        ];
                                     }
                                 }
                             }
@@ -275,7 +280,11 @@ impl<T: ImplicitClone + PartialEq + 'static> Component for Slider<T> {
                 onclick={(ctx.props().values.len() > 1).then(
                     || ctx.link().batch_callback(
                         |event: MouseEvent| {
-                            vec![Msg::PointerDown { pointer_id: None }, Msg::PointerMove { client_x: event.client_x() }, Msg::PointerUp]
+                            vec![
+                                Msg::PointerDown { pointer_id: None },
+                                Msg::PointerMove { client_x: event.client_x() },
+                                Msg::PointerUp
+                            ]
                         }
                     )
                 )}

--- a/src/slider.rs
+++ b/src/slider.rs
@@ -68,7 +68,6 @@ impl<T: ImplicitClone + PartialEq + 'static> Component for Slider<T> {
             Msg::PointerDown { pointer_id } if ctx.props().values.len() > 1 => {
                 if let Some(pointer_id) = pointer_id {
                     if let Some(slider) = self.slider_ref.cast::<Element>() {
-                        gloo::console::log!("capturing pointer for slider");
                         slider.set_pointer_capture(pointer_id).unwrap();
                     }
                 }


### PR DESCRIPTION
blueprintjs, even on v4, apparently only works on desktop targets (it uses mouse events), but I'm using yewprint for _something_ and I needed it to work on mobile devices. It seems pointer events + pointer capture is the way to go in 2023, so that's what this uses!

Tested on Chrome macOS, Firefox macOS, Safari macOS, and Chrome Android and it works fine. You can drag starting from the handle or starting from anywhere on the slider itself, you can still move the pointer up/down outside the slider while holding it, focusing the handle + using arrow keys still works as before.

I guess the only breaking change is that you can move the slider with a secondary mouse button now, but since PointerEvent inherits from MouseEvent it might be possible to re-add that restriction, if anyone cares about it enough.